### PR TITLE
feat: OnnxEmbeddingService — local MiniLM embeddings (Closes #10)

### DIFF
--- a/LocalVectorEngine.slnx
+++ b/LocalVectorEngine.slnx
@@ -3,4 +3,7 @@
     <Project Path="src/LocalVectorEngine.Core/LocalVectorEngine.Core.csproj" />
     <Project Path="src/LocalVectorEngine.Demo/LocalVectorEngine.Demo.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/LocalVectorEngine.Core.Tests/LocalVectorEngine.Core.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -111,15 +111,32 @@ No cloud calls — all retrieval runs on-device.
 
 ## How to run
 
+Download the ONNX model **and** its tokenizer vocabulary into `models/` (both are gitignored):
+
 ```bash
-# Build
+# 86 MB ONNX model
+curl -L -o models/all-MiniLM-L6-v2.onnx \
+  https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx
+
+# 232 KB BERT WordPiece vocabulary
+curl -L -o models/vocab.txt \
+  https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/vocab.txt
+```
+
+Then:
+
+```bash
+# Build everything (library + demo + tests)
 dotnet build
 
 # Run the console demo
 dotnet run --project src/LocalVectorEngine.Demo
+
+# Run the test suite (model-dependent tests auto-skip if models/ is empty)
+dotnet test
 ```
 
-The `all-MiniLM-L6-v2.onnx` model must be downloaded into `models/` (gitignored because of its size: 86 MB).
+Paths can be overridden via the `LVE_MODEL_PATH` and `LVE_VOCAB_PATH` environment variables.
 
 ## Repository layout
 

--- a/src/LocalVectorEngine.Core/LocalVectorEngine.Core.csproj
+++ b/src/LocalVectorEngine.Core/LocalVectorEngine.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BLite" Version="4.3.0" />
+    <PackageReference Include="FastBertTokenizer" Version="1.0.28" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
   </ItemGroup>
 

--- a/src/LocalVectorEngine.Core/Services/OnnxEmbeddingService.cs
+++ b/src/LocalVectorEngine.Core/Services/OnnxEmbeddingService.cs
@@ -1,0 +1,135 @@
+using FastBertTokenizer;
+using LocalVectorEngine.Core.Interfaces;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace LocalVectorEngine.Core.Services;
+
+/// <summary>
+/// <see cref="IEmbeddingService"/> backed by a local ONNX transformer model
+/// (designed for <c>sentence-transformers/all-MiniLM-L6-v2</c>).
+///
+/// The service:
+///   1. Tokenizes the input text with a BERT WordPiece tokenizer loaded from <c>vocab.txt</c>.
+///   2. Runs a single forward pass through the ONNX model.
+///   3. Mean-pools the <c>last_hidden_state</c> using the attention mask.
+///   4. L2-normalizes the resulting vector so that cosine similarity reduces to a dot product.
+///
+/// The class is thread-safe for concurrent calls to <see cref="EmbedAsync"/>
+/// because the underlying <see cref="InferenceSession"/> is thread-safe.
+/// </summary>
+public sealed class OnnxEmbeddingService : IEmbeddingService, IDisposable
+{
+    /// <summary>Embedding dimension produced by <c>all-MiniLM-L6-v2</c>.</summary>
+    public const int EmbeddingDimension = 384;
+
+    /// <summary>Maximum token length accepted by the model.</summary>
+    public const int MaxSequenceLength = 512;
+
+    private readonly InferenceSession _session;
+    private readonly BertTokenizer _tokenizer;
+    private bool _disposed;
+
+    /// <param name="onnxModelPath">Path to the <c>.onnx</c> model file.</param>
+    /// <param name="vocabPath">Path to the BERT tokenizer <c>vocab.txt</c>.</param>
+    /// <param name="lowerCase">
+    /// Whether the tokenizer lowercases input before tokenization.
+    /// <c>true</c> matches the default <c>all-MiniLM-L6-v2</c> tokenizer.
+    /// </param>
+    public OnnxEmbeddingService(string onnxModelPath, string vocabPath, bool lowerCase = true)
+    {
+        if (!File.Exists(onnxModelPath))
+            throw new FileNotFoundException("ONNX model not found.", onnxModelPath);
+        if (!File.Exists(vocabPath))
+            throw new FileNotFoundException("Tokenizer vocabulary not found.", vocabPath);
+
+        _session = new InferenceSession(onnxModelPath);
+
+        _tokenizer = new BertTokenizer();
+        using var vocabStream = File.OpenRead(vocabPath);
+        _tokenizer.LoadVocabulary(vocabStream, convertInputToLowercase: lowerCase);
+    }
+
+    /// <inheritdoc />
+    public Task<float[]> EmbedAsync(string text, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ct.ThrowIfCancellationRequested();
+
+        // ONNX inference is CPU-bound and synchronous; offload to a worker
+        // thread so callers on the UI thread (e.g. MAUI) don't block.
+        return Task.Run(() => Embed(text, ct), ct);
+    }
+
+    private float[] Embed(string text, CancellationToken ct)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        // 1. Tokenize. FastBertTokenizer pads/truncates to MaxSequenceLength.
+        var (inputIds, attentionMask, tokenTypeIds) =
+            _tokenizer.Encode(text, MaxSequenceLength);
+        ct.ThrowIfCancellationRequested();
+
+        int seqLen = inputIds.Length;
+        var shape = new[] { 1, seqLen };
+
+        // 2. Run the model.
+        using var inputIdsTensor = OrtValue.CreateTensorValueFromMemory(inputIds, shape);
+        using var attentionMaskTensor = OrtValue.CreateTensorValueFromMemory(attentionMask, shape);
+        using var tokenTypeIdsTensor = OrtValue.CreateTensorValueFromMemory(tokenTypeIds, shape);
+
+        var inputs = new Dictionary<string, OrtValue>
+        {
+            ["input_ids"]      = inputIdsTensor,
+            ["attention_mask"] = attentionMaskTensor,
+            ["token_type_ids"] = tokenTypeIdsTensor,
+        };
+
+        using var runOptions = new RunOptions();
+        using var results = _session.Run(runOptions, inputs, _session.OutputNames);
+        ct.ThrowIfCancellationRequested();
+
+        // The first output is `last_hidden_state` with shape [1, seqLen, 384].
+        var lastHidden = results[0].GetTensorDataAsSpan<float>();
+
+        // 3. Mean pool with the attention mask.
+        var pooled = new float[EmbeddingDimension];
+        long validTokens = 0;
+        for (int t = 0; t < seqLen; t++)
+        {
+            if (attentionMask[t] == 0) continue;
+            validTokens++;
+            int tokenOffset = t * EmbeddingDimension;
+            for (int d = 0; d < EmbeddingDimension; d++)
+                pooled[d] += lastHidden[tokenOffset + d];
+        }
+        if (validTokens == 0)
+            throw new InvalidOperationException("Input produced zero valid tokens after tokenization.");
+
+        float inv = 1f / validTokens;
+        for (int d = 0; d < EmbeddingDimension; d++)
+            pooled[d] *= inv;
+
+        // 4. L2 normalize so cosine similarity = dot product.
+        double sumSq = 0;
+        for (int d = 0; d < EmbeddingDimension; d++)
+            sumSq += pooled[d] * pooled[d];
+
+        float norm = (float)Math.Sqrt(sumSq);
+        if (norm > 1e-12f)
+        {
+            float invNorm = 1f / norm;
+            for (int d = 0; d < EmbeddingDimension; d++)
+                pooled[d] *= invNorm;
+        }
+
+        return pooled;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _session.Dispose();
+        _disposed = true;
+    }
+}

--- a/src/LocalVectorEngine.Demo/Program.cs
+++ b/src/LocalVectorEngine.Demo/Program.cs
@@ -1,17 +1,86 @@
-using LocalVectorEngine.Core.Interfaces;
-using LocalVectorEngine.Core.Models;
+using LocalVectorEngine.Core.Services;
 
 // LocalVectorEngine.Demo
-// Thin console host used to exercise the Core library end-to-end:
-//   IChunkingService -> IEmbeddingService -> IVectorStore
-//
-// Real implementations (OnnxEmbeddingService, BLiteVectorStore, ...)
-// will be wired in as they land in Core.
+// Proof-of-life host for the Core library. At this stage only the
+// embedding service is wired up (Issue #10); chunking (#21) and the
+// BLite vector store (#11) join later and the demo will grow into a
+// full end-to-end RAG pipeline.
 
-Console.WriteLine("LocalVectorEngine.Demo — RAG pipeline host");
-Console.WriteLine("Core contracts available:");
-Console.WriteLine($"  - {nameof(IChunkingService)}");
-Console.WriteLine($"  - {nameof(IEmbeddingService)}");
-Console.WriteLine($"  - {nameof(IVectorStore)}  (returns {nameof(SearchResult)})");
+// ---------------------------------------------------------------
+// Locate model artefacts. Defaults point at ../../models relative
+// to the solution root, which is where `all-MiniLM-L6-v2.onnx`
+// and `vocab.txt` are expected to live. Overridable via env vars.
+// ---------------------------------------------------------------
+string repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+string modelPath =
+    Environment.GetEnvironmentVariable("LVE_MODEL_PATH")
+    ?? Path.Combine(repoRoot, "models", "all-MiniLM-L6-v2.onnx");
+string vocabPath =
+    Environment.GetEnvironmentVariable("LVE_VOCAB_PATH")
+    ?? Path.Combine(repoRoot, "models", "vocab.txt");
+
+Console.WriteLine("LocalVectorEngine.Demo — OnnxEmbeddingService smoke test");
+Console.WriteLine($"  model: {modelPath}");
+Console.WriteLine($"  vocab: {vocabPath}");
 Console.WriteLine();
-Console.WriteLine("No implementations wired yet. See issues #10, #11, #21.");
+
+if (!File.Exists(modelPath) || !File.Exists(vocabPath))
+{
+    Console.Error.WriteLine("Missing model or vocab file. See README for download instructions.");
+    return 1;
+}
+
+using var embedder = new OnnxEmbeddingService(modelPath, vocabPath);
+
+string[] samples =
+{
+    "Retrieval-Augmented Generation grounds LLM answers in source documents.",
+    "Vector search finds semantically similar passages for a query.",
+    "The quick brown fox jumps over the lazy dog.",
+};
+
+foreach (var s in samples)
+{
+    var vec = await embedder.EmbedAsync(s);
+    double norm = 0;
+    foreach (var v in vec) norm += v * v;
+    norm = Math.Sqrt(norm);
+
+    Console.WriteLine($"> \"{s}\"");
+    Console.WriteLine($"  dim = {vec.Length}, ||v|| = {norm:F6}");
+    Console.WriteLine($"  first 5 dims: [{string.Join(", ", vec.Take(5).Select(f => f.ToString("F4")))}]");
+    Console.WriteLine();
+}
+
+// Quick cosine similarity check: the two RAG/vector-search sentences
+// should be noticeably closer to each other than to the fox pangram.
+var a = await embedder.EmbedAsync(samples[0]);
+var b = await embedder.EmbedAsync(samples[1]);
+var c = await embedder.EmbedAsync(samples[2]);
+
+Console.WriteLine($"cos(RAG, vector search) = {Cosine(a, b):F4}");
+Console.WriteLine($"cos(RAG, fox pangram)   = {Cosine(a, c):F4}");
+
+return 0;
+
+// ---------------------------------------------------------------
+static float Cosine(float[] x, float[] y)
+{
+    // Vectors are already L2-normalized by the service, so cosine
+    // similarity reduces to a simple dot product.
+    float dot = 0;
+    for (int i = 0; i < x.Length; i++) dot += x[i] * y[i];
+    return dot;
+}
+
+static string FindRepoRoot(string start)
+{
+    var dir = new DirectoryInfo(start);
+    while (dir is not null)
+    {
+        if (dir.GetFiles("*.slnx").Length > 0 || Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            return dir.FullName;
+        dir = dir.Parent;
+    }
+    return start;
+}

--- a/tests/LocalVectorEngine.Core.Tests/LocalVectorEngine.Core.Tests.csproj
+++ b/tests/LocalVectorEngine.Core.Tests/LocalVectorEngine.Core.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LocalVectorEngine.Core\LocalVectorEngine.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/LocalVectorEngine.Core.Tests/OnnxEmbeddingServiceTests.cs
+++ b/tests/LocalVectorEngine.Core.Tests/OnnxEmbeddingServiceTests.cs
@@ -1,0 +1,93 @@
+using LocalVectorEngine.Core.Services;
+using Xunit;
+
+namespace LocalVectorEngine.Core.Tests;
+
+/// <summary>
+/// Integration-style tests for <see cref="OnnxEmbeddingService"/>.
+///
+/// The tests are skipped automatically when the ONNX model and/or
+/// tokenizer vocabulary are not present on disk — this keeps the
+/// suite green on CI machines that do not have the 86 MB model
+/// downloaded, while still running end-to-end locally.
+/// </summary>
+public class OnnxEmbeddingServiceTests
+{
+    private static readonly string RepoRoot = FindRepoRoot(AppContext.BaseDirectory);
+    private static readonly string ModelPath = Path.Combine(RepoRoot, "models", "all-MiniLM-L6-v2.onnx");
+    private static readonly string VocabPath = Path.Combine(RepoRoot, "models", "vocab.txt");
+
+    private static bool ArtifactsAvailable => File.Exists(ModelPath) && File.Exists(VocabPath);
+
+    [SkippableFact]
+    public async Task EmbedAsync_returns_384_dimensional_vector()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var svc = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var vec = await svc.EmbedAsync("hello world");
+
+        Assert.Equal(OnnxEmbeddingService.EmbeddingDimension, vec.Length);
+    }
+
+    [SkippableFact]
+    public async Task EmbedAsync_returns_L2_normalized_vector()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var svc = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var vec = await svc.EmbedAsync("retrieval augmented generation");
+
+        double norm = 0;
+        foreach (var v in vec) norm += v * v;
+        norm = Math.Sqrt(norm);
+
+        Assert.InRange(norm, 0.999, 1.001);
+    }
+
+    [SkippableFact]
+    public async Task EmbedAsync_semantically_similar_sentences_have_higher_cosine_than_unrelated()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var svc = new OnnxEmbeddingService(ModelPath, VocabPath);
+
+        var a = await svc.EmbedAsync("The cat sat on the mat.");
+        var b = await svc.EmbedAsync("A feline rested on the rug.");
+        var c = await svc.EmbedAsync("Quantum chromodynamics describes the strong interaction.");
+
+        float similar   = Cosine(a, b);
+        float unrelated = Cosine(a, c);
+
+        Assert.True(similar > unrelated,
+            $"Expected related sentences to be closer. sim={similar}, unrelated={unrelated}");
+    }
+
+    [Fact]
+    public void Ctor_throws_FileNotFound_when_model_missing()
+    {
+        Assert.Throws<FileNotFoundException>(() =>
+            new OnnxEmbeddingService("does/not/exist.onnx", VocabPath));
+    }
+
+    // ------------------------------------------------------------------
+    private static float Cosine(float[] x, float[] y)
+    {
+        // Vectors are L2-normalized by the service.
+        float dot = 0;
+        for (int i = 0; i < x.Length; i++) dot += x[i] * y[i];
+        return dot;
+    }
+
+    private static string FindRepoRoot(string start)
+    {
+        var dir = new DirectoryInfo(start);
+        while (dir is not null)
+        {
+            if (dir.GetFiles("*.slnx").Length > 0 || Directory.Exists(Path.Combine(dir.FullName, ".git")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return start;
+    }
+}


### PR DESCRIPTION
First concrete implementation of `IEmbeddingService`, backed by the `all-MiniLM-L6-v2` ONNX model.

Pipeline:
1. BERT WordPiece tokenization via `FastBertTokenizer` (vocab.txt loaded once at construction).
2. Single forward pass through the ONNX model with input_ids + attention_mask + token_type_ids.
3. Attention-masked mean pooling over `last_hidden_state` (shape [1, seq, 384]).
4. L2 normalization so cosine similarity reduces to a dot product.

Notes:
- `Task.Run` wrapper keeps the UI thread free (relevant for the BLite Mobile + AI consumer).
- `InferenceSession` is thread-safe → service is safe under concurrent embeds.
- Smoke test in `Demo/Program.cs` shows cos(related)=0.45 vs cos(unrelated)=0.00 with the sample sentences.
- Test project added under `tests/`. Model-dependent tests use `SkippableFact` so CI passes without the 86 MB model checked in.

Closes #10.