### PR TITLE
Implement SlidingWindowChunkingService

### DIFF
--- a/src/LocalVectorEngine.Core/Services/SlidingWindowChunkingService.cs
+++ b/src/LocalVectorEngine.Core/Services/SlidingWindowChunkingService.cs
@@ -1,0 +1,82 @@
+using LocalVectorEngine.Core.Interfaces;
+using LocalVectorEngine.Core.Models;
+
+namespace LocalVectorEngine.Core.Services;
+
+/// <summary>
+/// Word-based sliding-window <see cref="IChunkingService"/>.
+///
+/// Splits the input text on whitespace and emits overlapping chunks of
+/// <c>ChunkSizeWords</c> words sliding by <c>(ChunkSizeWords - OverlapWords)</c>
+/// at each step.
+///
+/// Word-based chunking is intentionally decoupled from the embedding
+/// model's tokenizer: the chunker stays simple, deterministic, and
+/// reusable across different embedding back-ends. A modest chunk size
+/// (default 400 words) keeps every chunk comfortably below the 512-token
+/// limit of <c>all-MiniLM-L6-v2</c> for typical English text.
+/// </summary>
+public sealed class SlidingWindowChunkingService : IChunkingService
+{
+    /// <summary>Default chunk length in words.</summary>
+    public const int DefaultChunkSizeWords = 400;
+
+    /// <summary>Default overlap between consecutive chunks, in words.</summary>
+    public const int DefaultOverlapWords = 50;
+
+    private readonly int _chunkSize;
+    private readonly int _overlap;
+    private readonly int _step;
+
+    /// <param name="chunkSizeWords">Number of words per chunk. Must be &gt; 0.</param>
+    /// <param name="overlapWords">
+    /// Number of words shared between consecutive chunks.
+    /// Must be in <c>[0, chunkSizeWords)</c>.
+    /// </param>
+    public SlidingWindowChunkingService(
+        int chunkSizeWords = DefaultChunkSizeWords,
+        int overlapWords = DefaultOverlapWords)
+    {
+        if (chunkSizeWords <= 0)
+            throw new ArgumentOutOfRangeException(nameof(chunkSizeWords),
+                "Chunk size must be positive.");
+        if (overlapWords < 0)
+            throw new ArgumentOutOfRangeException(nameof(overlapWords),
+                "Overlap must be non-negative.");
+        if (overlapWords >= chunkSizeWords)
+            throw new ArgumentException(
+                "Overlap must be strictly smaller than chunk size, otherwise the window cannot advance.",
+                nameof(overlapWords));
+
+        _chunkSize = chunkSizeWords;
+        _overlap = overlapWords;
+        _step = chunkSizeWords - overlapWords;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<DocumentChunk> Chunk(string documentId, string text, string source)
+    {
+        ArgumentNullException.ThrowIfNull(documentId);
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (string.IsNullOrWhiteSpace(text))
+            yield break;
+
+        // Split on any run of whitespace (spaces, tabs, newlines) and drop empty entries.
+        var words = text.Split(default(char[]), StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0) yield break;
+
+        int chunkIndex = 0;
+        for (int start = 0; start < words.Length; start += _step)
+        {
+            int end = Math.Min(start + _chunkSize, words.Length);
+            string chunkText = string.Join(' ', words, start, end - start);
+
+            yield return new DocumentChunk(documentId, chunkIndex++, chunkText, source);
+
+            // The chunk we just emitted already covers the tail of the document.
+            if (end == words.Length) yield break;
+        }
+    }
+}

--- a/tests/LocalVectorEngine.Core.Tests/SlidingWindowChunkingServiceTests.cs
+++ b/tests/LocalVectorEngine.Core.Tests/SlidingWindowChunkingServiceTests.cs
@@ -1,0 +1,157 @@
+using LocalVectorEngine.Core.Models;
+using LocalVectorEngine.Core.Services;
+using Xunit;
+
+namespace LocalVectorEngine.Core.Tests;
+
+public class SlidingWindowChunkingServiceTests
+{
+    private const string DocId = "doc-1";
+    private const string Source = "memory://test";
+
+    // ---- constructor validation -------------------------------------
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(-1, 0)]
+    public void Ctor_rejects_non_positive_chunk_size(int chunkSize, int overlap)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new SlidingWindowChunkingService(chunkSize, overlap));
+    }
+
+    [Fact]
+    public void Ctor_rejects_negative_overlap()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new SlidingWindowChunkingService(100, -1));
+    }
+
+    [Theory]
+    [InlineData(100, 100)]
+    [InlineData(100, 150)]
+    public void Ctor_rejects_overlap_geq_chunk_size(int chunkSize, int overlap)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new SlidingWindowChunkingService(chunkSize, overlap));
+    }
+
+    // ---- empty / trivial inputs -------------------------------------
+
+    [Fact]
+    public void Chunk_returns_nothing_for_empty_text()
+    {
+        var svc = new SlidingWindowChunkingService();
+        Assert.Empty(svc.Chunk(DocId, "", Source));
+    }
+
+    [Fact]
+    public void Chunk_returns_nothing_for_whitespace_only_text()
+    {
+        var svc = new SlidingWindowChunkingService();
+        Assert.Empty(svc.Chunk(DocId, "   \n\t  ", Source));
+    }
+
+    [Fact]
+    public void Chunk_returns_single_chunk_when_text_fits_in_window()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 10, overlapWords: 2);
+        var text = "The quick brown fox jumps over the lazy dog";
+
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Single(chunks);
+        Assert.Equal(text, chunks[0].Text);
+        Assert.Equal(0, chunks[0].ChunkIndex);
+        Assert.Equal(DocId, chunks[0].DocumentId);
+        Assert.Equal(Source, chunks[0].Source);
+    }
+
+    // ---- sliding behaviour ------------------------------------------
+
+    [Fact]
+    public void Chunk_emits_overlapping_chunks_with_sequential_indexes()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 4, overlapWords: 1);
+
+        // 10 words -> step=3. Windows at offsets 0, 3, 6.
+        // The window starting at 6 (w6..w9) already covers the tail of the
+        // document, so no further chunk is emitted.
+        var text = "w0 w1 w2 w3 w4 w5 w6 w7 w8 w9";
+
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Equal(3, chunks.Count);
+
+        Assert.Equal("w0 w1 w2 w3", chunks[0].Text);
+        Assert.Equal("w3 w4 w5 w6", chunks[1].Text);
+        Assert.Equal("w6 w7 w8 w9", chunks[2].Text);
+
+        for (int i = 0; i < chunks.Count; i++)
+            Assert.Equal(i, chunks[i].ChunkIndex);
+    }
+
+    [Fact]
+    public void Chunk_overlap_is_exactly_overlap_words_between_consecutive_chunks()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 2);
+
+        var text = string.Join(' ', Enumerable.Range(0, 20).Select(i => $"w{i}"));
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        for (int i = 0; i < chunks.Count - 1; i++)
+        {
+            var prevWords = chunks[i].Text.Split(' ');
+            var nextWords = chunks[i + 1].Text.Split(' ');
+
+            // Last 2 words of chunk i must equal first 2 words of chunk i+1
+            // (only checked while the next chunk has at least overlap words,
+            // i.e. it's not the trailing tail of the document).
+            if (nextWords.Length < 2) continue;
+
+            Assert.Equal(prevWords[^2], nextWords[0]);
+            Assert.Equal(prevWords[^1], nextWords[1]);
+        }
+    }
+
+    [Fact]
+    public void Chunk_zero_overlap_produces_disjoint_chunks()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 3, overlapWords: 0);
+
+        var text = "w0 w1 w2 w3 w4 w5 w6 w7 w8";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal("w0 w1 w2", chunks[0].Text);
+        Assert.Equal("w3 w4 w5", chunks[1].Text);
+        Assert.Equal("w6 w7 w8", chunks[2].Text);
+    }
+
+    [Fact]
+    public void Chunk_propagates_document_id_and_source_to_every_chunk()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 3, overlapWords: 1);
+
+        var text = string.Join(' ', Enumerable.Range(0, 10).Select(i => $"w{i}"));
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.All(chunks, c =>
+        {
+            Assert.Equal(DocId, c.DocumentId);
+            Assert.Equal(Source, c.Source);
+        });
+    }
+
+    [Fact]
+    public void Chunk_collapses_irregular_whitespace_to_single_spaces()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 0);
+
+        var text = "alpha\tbeta\n\ngamma   delta";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Single(chunks);
+        Assert.Equal("alpha beta gamma delta", chunks[0].Text);
+    }
+}


### PR DESCRIPTION
Closes #21.

Word-based sliding-window chunker (default 400 words / 50 overlap), framework-agnostic and deterministic.

- Splits on any whitespace, normalizes irregular spacing
- Validates ctor args (chunk size > 0, overlap in [0, chunkSize))
- Yields empty for empty/whitespace input
- 11 unit tests covering ctor validation, sliding behaviour, exact overlap, zero overlap, and propagation of DocumentId / Source