### PR TITLE
Implement BLiteVectorStore with HNSW vector index

### DIFF
--- a/src/LocalVectorEngine.Core/Persistence/VectorChunkEntity.cs
+++ b/src/LocalVectorEngine.Core/Persistence/VectorChunkEntity.cs
@@ -1,0 +1,34 @@
+using BLite.Bson;
+
+namespace LocalVectorEngine.Core.Persistence;
+
+/// <summary>
+/// BLite entity that backs a single <see cref="Models.DocumentChunk"/>
+/// together with its embedding vector.
+///
+/// Kept separate from the public <c>DocumentChunk</c> record so that the
+/// persistence layer owns its own identity type (<see cref="ObjectId"/>)
+/// and storage-specific concerns do not leak into the domain model.
+/// </summary>
+public sealed class VectorChunkEntity
+{
+    public ObjectId Id { get; set; }
+
+    /// <summary>Identifier of the source document this chunk belongs to.</summary>
+    public string DocumentId { get; set; } = string.Empty;
+
+    /// <summary>Sequential 0-based index of the chunk inside its document.</summary>
+    public int ChunkIndex { get; set; }
+
+    /// <summary>Raw text of the chunk.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Origin of the chunk (file path, URL, in-memory tag, …).</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>
+    /// L2-normalized embedding vector. Must match
+    /// <see cref="Services.OnnxEmbeddingService.EmbeddingDimension"/>.
+    /// </summary>
+    public float[] Embedding { get; set; } = Array.Empty<float>();
+}

--- a/src/LocalVectorEngine.Core/Persistence/VectorStoreDbContext.cs
+++ b/src/LocalVectorEngine.Core/Persistence/VectorStoreDbContext.cs
@@ -1,0 +1,42 @@
+using BLite.Bson;
+using BLite.Core;
+using BLite.Core.Collections;
+using BLite.Core.Indexing;
+using BLite.Core.Metadata;
+
+namespace LocalVectorEngine.Core.Persistence;
+
+/// <summary>
+/// BLite <see cref="DocumentDbContext"/> that hosts a single collection of
+/// <see cref="VectorChunkEntity"/> backed by an HNSW vector index.
+///
+/// One context = one <c>.db</c> file on disk. Thread-safety and concurrency
+/// semantics are those provided by BLite itself.
+/// </summary>
+public partial class VectorStoreDbContext : DocumentDbContext
+{
+    /// <summary>Embedding dimension of <c>all-MiniLM-L6-v2</c>.</summary>
+    public const int EmbeddingDimension = 384;
+
+    /// <summary>Logical name of the vector index (used by direct-API lookups).</summary>
+    public const string VectorIndexName = "idx_chunk_embedding";
+
+    public DocumentCollection<ObjectId, VectorChunkEntity> Chunks { get; set; } = null!;
+
+    public VectorStoreDbContext(string databasePath) : base(databasePath)
+    {
+        InitializeCollections();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<VectorChunkEntity>()
+            .ToCollection("document_chunks")
+            .HasIndex(x => x.DocumentId)
+            .HasVectorIndex(
+                x => x.Embedding,
+                dimensions: EmbeddingDimension,
+                metric: VectorMetric.Cosine,
+                name: VectorIndexName);
+    }
+}

--- a/src/LocalVectorEngine.Core/Services/BLiteVectorStore.cs
+++ b/src/LocalVectorEngine.Core/Services/BLiteVectorStore.cs
@@ -1,0 +1,147 @@
+using BLite.Core;
+using BLite.Core.Indexing;
+using BLite.Core.Query;
+using LocalVectorEngine.Core.Interfaces;
+using LocalVectorEngine.Core.Models;
+using LocalVectorEngine.Core.Persistence;
+
+namespace LocalVectorEngine.Core.Services;
+
+/// <summary>
+/// <see cref="IVectorStore"/> backed by a local BLite database with a
+/// built-in HNSW index over the 384-dim chunk embeddings.
+///
+/// The store is the persistence half of the RAG pipeline:
+///   * <see cref="StoreChunkAsync"/> persists chunk + vector on indexing.
+///   * <see cref="SearchAsync"/> runs an approximate k-NN cosine query.
+///
+/// <para>
+/// BLite returns matching entities in similarity order but does not expose
+/// per-result scores. Because <c>OnnxEmbeddingService</c> emits
+/// L2-normalized vectors, cosine similarity is equivalent to the dot
+/// product, which is computed here post-hoc so the caller gets a
+/// meaningful score in <see cref="SearchResult.Score"/> (in <c>[-1, 1]</c>,
+/// typically in <c>[0, 1]</c> for related text).
+/// </para>
+/// </summary>
+public sealed class BLiteVectorStore : IVectorStore, IDisposable
+{
+    /// <summary>Embedding dimension enforced on every <c>StoreChunkAsync</c> call.</summary>
+    public const int EmbeddingDimension = VectorStoreDbContext.EmbeddingDimension;
+
+    private readonly VectorStoreDbContext _db;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private bool _disposed;
+
+    /// <param name="databasePath">
+    /// Path of the BLite <c>.db</c> file. The directory must exist;
+    /// the file itself is created on first write.
+    /// </param>
+    public BLiteVectorStore(string databasePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
+
+        var dir = Path.GetDirectoryName(Path.GetFullPath(databasePath));
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            throw new DirectoryNotFoundException(
+                $"Directory for BLite database does not exist: {dir}");
+
+        _db = new VectorStoreDbContext(databasePath);
+    }
+
+    /// <inheritdoc />
+    public async Task StoreChunkAsync(
+        DocumentChunk chunk,
+        float[] embedding,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(chunk);
+        ArgumentNullException.ThrowIfNull(embedding);
+
+        if (embedding.Length != EmbeddingDimension)
+            throw new ArgumentException(
+                $"Embedding has {embedding.Length} dims but the store expects {EmbeddingDimension}.",
+                nameof(embedding));
+
+        ct.ThrowIfCancellationRequested();
+
+        // BLite's write path is not guaranteed to be safe under concurrent
+        // writers on the same context, so we serialize Insert calls ourselves.
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var entity = new VectorChunkEntity
+            {
+                DocumentId = chunk.DocumentId,
+                ChunkIndex = chunk.ChunkIndex,
+                Text       = chunk.Text,
+                Source     = chunk.Source,
+                Embedding  = embedding,
+            };
+
+            await _db.Chunks.InsertAsync(entity).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SearchResult>> SearchAsync(
+        float[] queryEmbedding,
+        int topK,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(queryEmbedding);
+        if (topK <= 0)
+            throw new ArgumentOutOfRangeException(nameof(topK), "topK must be positive.");
+        if (queryEmbedding.Length != EmbeddingDimension)
+            throw new ArgumentException(
+                $"Query has {queryEmbedding.Length} dims but the store expects {EmbeddingDimension}.",
+                nameof(queryEmbedding));
+
+        ct.ThrowIfCancellationRequested();
+
+        // HNSW KNN via the LINQ-shaped marker extension.
+        var hits = await _db.Chunks
+            .AsQueryable()
+            .Where(x => x.Embedding.VectorSearch(queryEmbedding, topK))
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        ct.ThrowIfCancellationRequested();
+
+        // BLite does not surface per-result scores, so we recompute cosine
+        // similarity ourselves. Embeddings are L2-normalized upstream, which
+        // reduces cosine similarity to a plain dot product.
+        var results = new List<SearchResult>(hits.Count);
+        foreach (var hit in hits)
+        {
+            var score = DotProduct(queryEmbedding, hit.Embedding);
+            var chunk = new DocumentChunk(hit.DocumentId, hit.ChunkIndex, hit.Text, hit.Source);
+            results.Add(new SearchResult(chunk, score));
+        }
+
+        return results;
+    }
+
+    private static float DotProduct(float[] a, float[] b)
+    {
+        // Lengths are guaranteed equal by the ctor-time dimension check.
+        double sum = 0;
+        for (int i = 0; i < a.Length; i++)
+            sum += a[i] * b[i];
+        return (float)sum;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _db.Dispose();
+        _writeLock.Dispose();
+        _disposed = true;
+    }
+}

--- a/tests/LocalVectorEngine.Core.Tests/BLiteVectorStoreTests.cs
+++ b/tests/LocalVectorEngine.Core.Tests/BLiteVectorStoreTests.cs
@@ -1,0 +1,214 @@
+using LocalVectorEngine.Core.Models;
+using LocalVectorEngine.Core.Services;
+using Xunit;
+
+namespace LocalVectorEngine.Core.Tests;
+
+/// <summary>
+/// Integration-ish unit tests for <see cref="BLiteVectorStore"/>.
+///
+/// Each test uses a unique temp <c>.db</c> file derived from the calling
+/// method name and deletes it in a <c>try/finally</c>, so test runs are
+/// hermetic and can execute in parallel.
+/// </summary>
+public sealed class BLiteVectorStoreTests
+{
+    private const int Dim = BLiteVectorStore.EmbeddingDimension; // 384
+
+    // ---- test helpers -----------------------------------------------------
+
+    /// <summary>Returns a one-hot unit vector of size <see cref="Dim"/>.</summary>
+    private static float[] OneHot(int position)
+    {
+        var v = new float[Dim];
+        v[position] = 1f;
+        return v;
+    }
+
+    private static string TempDbPath([System.Runtime.CompilerServices.CallerMemberName] string name = "")
+        => Path.Combine(Path.GetTempPath(), $"lve_blite_{name}_{Guid.NewGuid():N}.db");
+
+    private static DocumentChunk Chunk(string docId, int idx, string text = "sample", string source = "mem://t")
+        => new(docId, idx, text, source);
+
+    // ---- constructor validation ------------------------------------------
+
+    [Fact]
+    public void Ctor_rejects_null_or_whitespace_path()
+    {
+        Assert.Throws<ArgumentException>(() => new BLiteVectorStore("   "));
+        Assert.Throws<ArgumentException>(() => new BLiteVectorStore(""));
+        Assert.Throws<ArgumentNullException>(() => new BLiteVectorStore(null!));
+    }
+
+    [Fact]
+    public void Ctor_rejects_missing_directory()
+    {
+        var bogus = Path.Combine(Path.GetTempPath(), $"does_not_exist_{Guid.NewGuid():N}", "db.db");
+        Assert.Throws<DirectoryNotFoundException>(() => new BLiteVectorStore(bogus));
+    }
+
+    // ---- StoreChunkAsync validation --------------------------------------
+
+    [Fact]
+    public async Task StoreChunk_rejects_wrong_dimension()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                store.StoreChunkAsync(Chunk("d", 0), new float[Dim - 1]));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task StoreChunk_rejects_null_chunk_or_embedding()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                store.StoreChunkAsync(null!, OneHot(0)));
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                store.StoreChunkAsync(Chunk("d", 0), null!));
+        }
+        finally { File.Delete(path); }
+    }
+
+    // ---- SearchAsync validation ------------------------------------------
+
+    [Fact]
+    public async Task Search_rejects_wrong_dimension()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                store.SearchAsync(new float[Dim + 1], 3));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_rejects_non_positive_topK()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                store.SearchAsync(OneHot(0), 0));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                store.SearchAsync(OneHot(0), -1));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_on_empty_store_returns_empty()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+            var results = await store.SearchAsync(OneHot(0), 5);
+            Assert.Empty(results);
+        }
+        finally { File.Delete(path); }
+    }
+
+    // ---- round-trip behaviour --------------------------------------------
+
+    [Fact]
+    public async Task Search_returns_closest_chunk_first()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            await store.StoreChunkAsync(Chunk("doc-A", 0, "alpha"), OneHot(0));
+            await store.StoreChunkAsync(Chunk("doc-B", 0, "beta"),  OneHot(1));
+            await store.StoreChunkAsync(Chunk("doc-C", 0, "gamma"), OneHot(2));
+
+            // Query = OneHot(1). Expected top-1: doc-B (score ~= 1),
+            // the other two are orthogonal (score 0).
+            var results = await store.SearchAsync(OneHot(1), topK: 3);
+
+            Assert.NotEmpty(results);
+            Assert.Equal("doc-B", results[0].Chunk.DocumentId);
+            Assert.Equal("beta",  results[0].Chunk.Text);
+            Assert.True(results[0].Score > 0.99f,
+                $"expected cosine ~1.0 for identical one-hot, got {results[0].Score}");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_preserves_chunk_metadata_roundtrip()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            var original = new DocumentChunk("doc-42", 7, "the quick brown fox", "file:///tmp/foo.md");
+            await store.StoreChunkAsync(original, OneHot(3));
+
+            var results = await store.SearchAsync(OneHot(3), topK: 1);
+
+            Assert.Single(results);
+            var got = results[0].Chunk;
+            Assert.Equal(original.DocumentId, got.DocumentId);
+            Assert.Equal(original.ChunkIndex, got.ChunkIndex);
+            Assert.Equal(original.Text,       got.Text);
+            Assert.Equal(original.Source,     got.Source);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_survives_close_and_reopen()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using (var store = new BLiteVectorStore(path))
+            {
+                await store.StoreChunkAsync(Chunk("doc-X", 0, "persisted"), OneHot(5));
+            } // dispose + flush
+
+            using (var reopened = new BLiteVectorStore(path))
+            {
+                var results = await reopened.SearchAsync(OneHot(5), topK: 1);
+                Assert.Single(results);
+                Assert.Equal("doc-X", results[0].Chunk.DocumentId);
+                Assert.Equal("persisted", results[0].Chunk.Text);
+            }
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // ---- lifecycle --------------------------------------------------------
+
+    [Fact]
+    public async Task Disposed_store_throws_on_further_use()
+    {
+        var path = TempDbPath();
+        try
+        {
+            var store = new BLiteVectorStore(path);
+            store.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                store.StoreChunkAsync(Chunk("d", 0), OneHot(0)));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                store.SearchAsync(OneHot(0), 1));
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+}


### PR DESCRIPTION
Closes #11.

Local persistence + KNN search backed by BLite 4.3.0.

- `VectorChunkEntity` POCO + `VectorStoreDbContext` (DocumentDbContext) with cosine HNSW index on the 384-dim embedding and a secondary index on `DocumentId`.
- `BLiteVectorStore : IVectorStore, IDisposable` — serialized writes via `SemaphoreSlim`, dimension validation, scores recomputed as dot product (embeddings are L2-normalized upstream).
- 11 unit tests covering ctor validation, dimension checks, empty-store search, closest-first ordering, metadata round-trip, persistence across close/reopen, and post-dispose guards.