### PR TITLE
feat(cli): CLI interface with index/query/demo commands

### DIFF
--- a/samples/rag_overview.txt
+++ b/samples/rag_overview.txt
@@ -1,0 +1,52 @@
+Retrieval-Augmented Generation (RAG) is an AI architecture pattern that enhances Large Language
+Model (LLM) responses by grounding them in external, up-to-date knowledge sources. Traditional
+LLMs are limited to what they learned during training and have a fixed knowledge cut-off. RAG
+solves this by adding a retrieval step before generation: relevant documents are fetched and
+passed to the model as context, allowing it to produce accurate, grounded answers.
+
+The RAG pipeline has two main phases. The first phase is indexing, which happens once per
+document. During indexing, the source document is split into overlapping chunks of roughly 400
+words each. Each chunk is then transformed into a dense vector (an embedding) using a neural
+network such as all-MiniLM-L6-v2, which produces 384-dimensional vectors. These embeddings
+capture the semantic meaning of the text, not just keyword matches. Finally, the chunk metadata
+and its embedding are stored in a vector database that supports efficient similarity search.
+
+The second phase is querying, which runs every time a user asks a question. The user's question
+is embedded using the same model, producing a query vector in the same 384-dimensional space.
+This query vector is then compared against all stored embeddings using an approximate nearest-
+neighbour search algorithm. The top-K most similar chunks are retrieved and presented as context
+to the LLM, which uses them to formulate a grounded, evidence-based answer.
+
+Vector similarity search is the core of the retrieval step. The most common metric is cosine
+similarity, which measures the angle between two vectors. When vectors are L2-normalized (unit
+length), cosine similarity reduces to a simple dot product, making computation extremely fast.
+For large-scale datasets, exact nearest-neighbour search becomes too slow, so approximate
+algorithms like HNSW (Hierarchical Navigable Small World) are used instead.
+
+HNSW is a graph-based algorithm that builds a multi-layer proximity graph. Each node represents
+a vector, and edges connect each node to its nearest neighbours. During search, the algorithm
+starts from an entry point at the top layer and navigates through the graph, moving to closer
+neighbours at each step, descending through layers for finer granularity. This approach achieves
+O(log N) search complexity while maintaining high recall, making it ideal for real-time
+retrieval in RAG systems.
+
+The embedding model used in this project is all-MiniLM-L6-v2, a compact Sentence Transformer
+model based on the BERT architecture. It produces 384-dimensional embeddings and supports a
+maximum sequence length of 512 tokens. The model is run locally using ONNX Runtime, which
+allows efficient inference without requiring a GPU or cloud API calls. The embedding process
+involves BERT WordPiece tokenization, an ONNX forward pass, mean pooling across the attention
+mask, and L2 normalization of the output vector.
+
+Chunking is the process of splitting a document into smaller, overlapping segments. The sliding
+window approach used here moves a fixed-size window (default: 400 words) across the document
+with a configurable overlap (default: 50 words). The overlap ensures that important context at
+chunk boundaries is not lost. Each chunk is assigned a sequential index and retains metadata
+linking it back to its source document.
+
+The vector store in this project uses BLite, a lightweight embedded database that supports
+built-in HNSW vector indexing. BLite stores chunks as BSON documents in a single database file
+on disk, making it ideal for local, self-contained applications. The store enforces a fixed
+embedding dimension of 384 and uses cosine distance as the similarity metric. Because the
+embeddings are L2-normalized upstream, the cosine similarity between any two vectors can be
+computed as their dot product, which the store calculates post-hoc since BLite's HNSW search
+returns ranked results without individual scores.

--- a/src/LocalVectorEngine.Demo/Program.cs
+++ b/src/LocalVectorEngine.Demo/Program.cs
@@ -1,77 +1,215 @@
+using LocalVectorEngine.Core.Indexing;
+using LocalVectorEngine.Core.Retrieval;
 using LocalVectorEngine.Core.Services;
 
-// LocalVectorEngine.Demo
-// Proof-of-life host for the Core library. At this stage only the
-// embedding service is wired up (Issue #10); chunking (#21) and the
-// BLite vector store (#11) join later and the demo will grow into a
-// full end-to-end RAG pipeline.
+// ═══════════════════════════════════════════════════════════════════════
+// LocalVectorEngine.Demo — CLI that exercises the full RAG pipeline
+//
+//   dotnet run --project src/LocalVectorEngine.Demo -- index <file>
+//   dotnet run --project src/LocalVectorEngine.Demo -- query "your question"
+//   dotnet run --project src/LocalVectorEngine.Demo -- demo
+//
+// The "demo" command indexes the sample document shipped in samples/
+// and then runs a few pre-canned queries to show the pipeline end-to-end.
+// ═══════════════════════════════════════════════════════════════════════
 
-// ---------------------------------------------------------------
-// Locate model artefacts. Defaults point at ../../models relative
-// to the solution root, which is where `all-MiniLM-L6-v2.onnx`
-// and `vocab.txt` are expected to live. Overridable via env vars.
-// ---------------------------------------------------------------
-string repoRoot = FindRepoRoot(AppContext.BaseDirectory);
-string modelPath =
-    Environment.GetEnvironmentVariable("LVE_MODEL_PATH")
-    ?? Path.Combine(repoRoot, "models", "all-MiniLM-L6-v2.onnx");
-string vocabPath =
-    Environment.GetEnvironmentVariable("LVE_VOCAB_PATH")
-    ?? Path.Combine(repoRoot, "models", "vocab.txt");
+// ── Locate artefacts ────────────────────────────────────────────────────
+string repoRoot  = FindRepoRoot(AppContext.BaseDirectory);
+string modelPath = Env("LVE_MODEL_PATH") ?? Path.Combine(repoRoot, "models", "all-MiniLM-L6-v2.onnx");
+string vocabPath = Env("LVE_VOCAB_PATH") ?? Path.Combine(repoRoot, "models", "vocab.txt");
+string dbPath    = Env("LVE_DB_PATH")    ?? Path.Combine(repoRoot, "data", "vectorstore.db");
 
-Console.WriteLine("LocalVectorEngine.Demo — OnnxEmbeddingService smoke test");
-Console.WriteLine($"  model: {modelPath}");
-Console.WriteLine($"  vocab: {vocabPath}");
-Console.WriteLine();
-
-if (!File.Exists(modelPath) || !File.Exists(vocabPath))
+if (args.Length == 0)
 {
-    Console.Error.WriteLine("Missing model or vocab file. See README for download instructions.");
+    PrintUsage();
     return 1;
 }
 
+string command = args[0].ToLowerInvariant();
+
+// ── Pre-flight checks ───────────────────────────────────────────────────
+if (!File.Exists(modelPath) || !File.Exists(vocabPath))
+{
+    Console.Error.WriteLine("ERROR: Missing ONNX model or vocab file.");
+    Console.Error.WriteLine($"  model: {modelPath}");
+    Console.Error.WriteLine($"  vocab: {vocabPath}");
+    Console.Error.WriteLine("See README for download instructions.");
+    return 1;
+}
+
+// Ensure the database directory exists.
+var dbDir = Path.GetDirectoryName(Path.GetFullPath(dbPath));
+if (!string.IsNullOrEmpty(dbDir) && !Directory.Exists(dbDir))
+    Directory.CreateDirectory(dbDir);
+
+// ── Wire up the services (manual DI) ────────────────────────────────────
 using var embedder = new OnnxEmbeddingService(modelPath, vocabPath);
+var chunker = new SlidingWindowChunkingService(chunkSizeWords: 100, overlapWords: 25);
 
-string[] samples =
+// BLiteVectorStore is IDisposable — we create/dispose per command because
+// the DB file is a single-writer resource.
+switch (command)
 {
-    "Retrieval-Augmented Generation grounds LLM answers in source documents.",
-    "Vector search finds semantically similar passages for a query.",
-    "The quick brown fox jumps over the lazy dog.",
-};
+    case "index":
+        return await RunIndex(args);
 
-foreach (var s in samples)
+    case "query":
+        return await RunQuery(args);
+
+    case "demo":
+        return await RunDemo();
+
+    default:
+        Console.Error.WriteLine($"Unknown command: {command}");
+        PrintUsage();
+        return 1;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Commands
+// ═══════════════════════════════════════════════════════════════════════
+
+async Task<int> RunIndex(string[] a)
 {
-    var vec = await embedder.EmbedAsync(s);
-    double norm = 0;
-    foreach (var v in vec) norm += v * v;
-    norm = Math.Sqrt(norm);
+    if (a.Length < 2)
+    {
+        Console.Error.WriteLine("Usage: index <file> [file2 …]");
+        return 1;
+    }
 
-    Console.WriteLine($"> \"{s}\"");
-    Console.WriteLine($"  dim = {vec.Length}, ||v|| = {norm:F6}");
-    Console.WriteLine($"  first 5 dims: [{string.Join(", ", vec.Take(5).Select(f => f.ToString("F4")))}]");
+    using var store   = new BLiteVectorStore(dbPath);
+    var indexer       = new DocumentIndexer(chunker, embedder, store);
+    int totalChunks   = 0;
+
+    for (int i = 1; i < a.Length; i++)
+    {
+        var filePath = a[i];
+        if (!File.Exists(filePath))
+        {
+            Console.Error.WriteLine($"File not found: {filePath}");
+            continue;
+        }
+
+        Console.Write($"Indexing {Path.GetFileName(filePath)} … ");
+        int n = await indexer.IndexFileAsync(filePath);
+        Console.WriteLine($"{n} chunks stored.");
+        totalChunks += n;
+    }
+
+    Console.WriteLine($"\nDone — {totalChunks} chunks indexed into {dbPath}");
+    return 0;
+}
+
+async Task<int> RunQuery(string[] a)
+{
+    if (a.Length < 2)
+    {
+        Console.Error.WriteLine("Usage: query \"your question here\"");
+        return 1;
+    }
+
+    string question = string.Join(' ', a.Skip(1));
+
+    using var store = new BLiteVectorStore(dbPath);
+    var retriever   = new RetrievalEngine(embedder, store);
+
+    Console.WriteLine($"Question: {question}\n");
+
+    var results = await retriever.RetrieveAsync(question, topK: 5);
+
+    if (results.Count == 0)
+    {
+        Console.WriteLine("No results. Have you indexed any documents yet?");
+        return 0;
+    }
+
+    for (int i = 0; i < results.Count; i++)
+    {
+        var r = results[i];
+        Console.WriteLine($"── Result {i + 1}  (score: {r.Score:F4}) ──");
+        Console.WriteLine($"   Source: {r.Chunk.Source} [chunk {r.Chunk.ChunkIndex}]");
+        Console.WriteLine($"   {Truncate(r.Chunk.Text, 200)}");
+        Console.WriteLine();
+    }
+
+    return 0;
+}
+
+async Task<int> RunDemo()
+{
+    string sampleDir = Path.Combine(repoRoot, "samples");
+    string sampleFile = Path.Combine(sampleDir, "rag_overview.txt");
+
+    if (!File.Exists(sampleFile))
+    {
+        Console.Error.WriteLine($"Sample file not found: {sampleFile}");
+        Console.Error.WriteLine("Make sure the samples/ directory exists in the repo root.");
+        return 1;
+    }
+
+    // ── Index ──
+    Console.WriteLine("╔══════════════════════════════════════════════════╗");
+    Console.WriteLine("║  LocalVectorEngine — End-to-End Demo            ║");
+    Console.WriteLine("╚══════════════════════════════════════════════════╝\n");
+
+    using var store = new BLiteVectorStore(dbPath);
+    var indexer     = new DocumentIndexer(chunker, embedder, store);
+    var retriever   = new RetrievalEngine(embedder, store);
+
+    Console.Write($"Indexing {Path.GetFileName(sampleFile)} … ");
+    int chunks = await indexer.IndexFileAsync(sampleFile);
+    Console.WriteLine($"{chunks} chunks stored.\n");
+
+    // ── Query ──
+    string[] questions =
+    {
+        "What is Retrieval-Augmented Generation?",
+        "How does HNSW search work?",
+        "What is the embedding dimension of MiniLM?",
+    };
+
+    foreach (var q in questions)
+    {
+        Console.WriteLine($"Q: {q}");
+        var results = await retriever.RetrieveAsync(q, topK: 3);
+
+        for (int i = 0; i < results.Count; i++)
+        {
+            var r = results[i];
+            Console.WriteLine($"  [{i + 1}] score={r.Score:F4}  chunk#{r.Chunk.ChunkIndex}  \"{Truncate(r.Chunk.Text, 120)}\"");
+        }
+        Console.WriteLine();
+    }
+
+    Console.WriteLine("Demo complete.");
+    return 0;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════
+
+void PrintUsage()
+{
+    Console.WriteLine("LocalVectorEngine.Demo — local RAG pipeline CLI\n");
+    Console.WriteLine("Commands:");
+    Console.WriteLine("  index <file> [file2 …]     Index one or more text files");
+    Console.WriteLine("  query \"your question\"       Retrieve top-K passages");
+    Console.WriteLine("  demo                        Index sample doc + run sample queries");
     Console.WriteLine();
+    Console.WriteLine("Environment variables:");
+    Console.WriteLine("  LVE_MODEL_PATH   Path to all-MiniLM-L6-v2.onnx");
+    Console.WriteLine("  LVE_VOCAB_PATH   Path to vocab.txt");
+    Console.WriteLine("  LVE_DB_PATH      Path to BLite database file");
 }
 
-// Quick cosine similarity check: the two RAG/vector-search sentences
-// should be noticeably closer to each other than to the fox pangram.
-var a = await embedder.EmbedAsync(samples[0]);
-var b = await embedder.EmbedAsync(samples[1]);
-var c = await embedder.EmbedAsync(samples[2]);
-
-Console.WriteLine($"cos(RAG, vector search) = {Cosine(a, b):F4}");
-Console.WriteLine($"cos(RAG, fox pangram)   = {Cosine(a, c):F4}");
-
-return 0;
-
-// ---------------------------------------------------------------
-static float Cosine(float[] x, float[] y)
+static string Truncate(string text, int maxLen)
 {
-    // Vectors are already L2-normalized by the service, so cosine
-    // similarity reduces to a simple dot product.
-    float dot = 0;
-    for (int i = 0; i < x.Length; i++) dot += x[i] * y[i];
-    return dot;
+    var oneLine = text.ReplaceLineEndings(" ");
+    return oneLine.Length <= maxLen ? oneLine : oneLine[..maxLen] + "…";
 }
+
+static string? Env(string name) => Environment.GetEnvironmentVariable(name);
 
 static string FindRepoRoot(string start)
 {


### PR DESCRIPTION
Closes #16

- Rewrote `Program.cs` with three commands: `index <file>`, `query "question"`, `demo`
- `index` uses `DocumentIndexer` to chunk → embed → store any text file
- `query` uses `RetrievalEngine` to embed question → k-NN search → print top-K with scores
- `demo` indexes `samples/rag_overview.txt` and runs 3 pre-canned queries end-to-end
- Tuned chunking to 100 words / 25 overlap for better retrieval precision on short docs
- DB auto-created in `data/vectorstore.db`, overridable via `LVE_DB_PATH`
- Added `samples/rag_overview.txt` as demo document