### PR TITLE
test: edge-case + end-to-end integration tests

### DIFF
--- a/tests/LocalVectorEngine.Core.Tests/BLiteVectorStoreEdgeCaseTests.cs
+++ b/tests/LocalVectorEngine.Core.Tests/BLiteVectorStoreEdgeCaseTests.cs
@@ -1,0 +1,162 @@
+using LocalVectorEngine.Core.Models;
+using LocalVectorEngine.Core.Services;
+using Xunit;
+
+namespace LocalVectorEngine.Core.Tests;
+
+/// <summary>
+/// Additional edge-case coverage for <see cref="BLiteVectorStore"/>.
+/// </summary>
+public sealed class BLiteVectorStoreEdgeCaseTests
+{
+    private const int Dim = BLiteVectorStore.EmbeddingDimension;
+
+    private static float[] OneHot(int pos)
+    {
+        var v = new float[Dim];
+        v[pos] = 1f;
+        return v;
+    }
+
+    private static string TempDbPath([System.Runtime.CompilerServices.CallerMemberName] string name = "")
+        => Path.Combine(Path.GetTempPath(), $"lve_blite_edge_{name}_{Guid.NewGuid():N}.db");
+
+    [Fact]
+    public async Task Search_topK_limits_results_even_when_more_are_stored()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            // Store 5 chunks in different directions.
+            for (int i = 0; i < 5; i++)
+                await store.StoreChunkAsync(new DocumentChunk("doc", i, $"chunk{i}", "src"), OneHot(i));
+
+            var results = await store.SearchAsync(OneHot(0), topK: 2);
+
+            Assert.Equal(2, results.Count);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_returns_fewer_than_topK_when_store_has_less()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+            await store.StoreChunkAsync(new DocumentChunk("doc", 0, "only one", "src"), OneHot(0));
+
+            var results = await store.SearchAsync(OneHot(0), topK: 10);
+
+            Assert.Single(results);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task StoreChunk_allows_same_documentId_different_chunkIndex()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            await store.StoreChunkAsync(new DocumentChunk("doc-A", 0, "first",  "src"), OneHot(0));
+            await store.StoreChunkAsync(new DocumentChunk("doc-A", 1, "second", "src"), OneHot(1));
+
+            // Both should be searchable.
+            var results = await store.SearchAsync(OneHot(1), topK: 2);
+            Assert.Equal(2, results.Count);
+            Assert.Equal("second", results[0].Chunk.Text); // closest
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_returns_mixed_results_from_multiple_documents()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            await store.StoreChunkAsync(new DocumentChunk("doc-A", 0, "alpha", "src-A"), OneHot(0));
+            await store.StoreChunkAsync(new DocumentChunk("doc-B", 0, "beta",  "src-B"), OneHot(1));
+            await store.StoreChunkAsync(new DocumentChunk("doc-C", 0, "gamma", "src-C"), OneHot(2));
+
+            // Query a direction between OneHot(0) and OneHot(1).
+            var query = new float[Dim];
+            query[0] = 0.7f;
+            query[1] = 0.7f;
+            // Not normalized, but that's fine for testing ordering.
+
+            var results = await store.SearchAsync(query, topK: 3);
+
+            Assert.Equal(3, results.Count);
+            // doc-A and doc-B should both appear in results.
+            var docIds = results.Select(r => r.Chunk.DocumentId).ToList();
+            Assert.Contains("doc-A", docIds);
+            Assert.Contains("doc-B", docIds);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task StoreChunk_handles_long_text_content()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            var longText = new string('x', 10_000);
+            var chunk = new DocumentChunk("big", 0, longText, "src");
+            await store.StoreChunkAsync(chunk, OneHot(0));
+
+            var results = await store.SearchAsync(OneHot(0), topK: 1);
+            Assert.Single(results);
+            Assert.Equal(10_000, results[0].Chunk.Text.Length);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task StoreChunk_handles_unicode_metadata()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            var chunk = new DocumentChunk("日本語ドキュメント", 0, "Le café résumé über straße", "ファイル://テスト");
+            await store.StoreChunkAsync(chunk, OneHot(7));
+
+            var results = await store.SearchAsync(OneHot(7), topK: 1);
+            Assert.Single(results);
+            Assert.Equal("日本語ドキュメント", results[0].Chunk.DocumentId);
+            Assert.Equal("Le café résumé über straße", results[0].Chunk.Text);
+            Assert.Equal("ファイル://テスト", results[0].Chunk.Source);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Search_scores_are_in_expected_range()
+    {
+        var path = TempDbPath();
+        try
+        {
+            using var store = new BLiteVectorStore(path);
+
+            await store.StoreChunkAsync(new DocumentChunk("d", 0, "t", "s"), OneHot(0));
+
+            // Query with same direction → score ≈ 1
+            var results = await store.SearchAsync(OneHot(0), topK: 1);
+            Assert.InRange(results[0].Score, 0.99f, 1.01f);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/LocalVectorEngine.Core.Tests/EndToEndIntegrationTests.cs
+++ b/tests/LocalVectorEngine.Core.Tests/EndToEndIntegrationTests.cs
@@ -1,0 +1,184 @@
+using LocalVectorEngine.Core.Indexing;
+using LocalVectorEngine.Core.Retrieval;
+using LocalVectorEngine.Core.Services;
+using Xunit;
+
+namespace LocalVectorEngine.Core.Tests;
+
+/// <summary>
+/// End-to-end integration tests that wire the real services together:
+/// <c>SlidingWindowChunkingService</c> → <c>OnnxEmbeddingService</c> → <c>BLiteVectorStore</c>.
+///
+/// These tests exercise the full RAG pipeline (indexing + retrieval) using the
+/// actual ONNX model and a real BLite database. They are automatically skipped
+/// when the ONNX model or vocab file is not present on disk, keeping CI green
+/// on machines that don't have the 86 MB model downloaded.
+/// </summary>
+public sealed class EndToEndIntegrationTests : IDisposable
+{
+    private static readonly string RepoRoot = FindRepoRoot(AppContext.BaseDirectory);
+    private static readonly string ModelPath = Path.Combine(RepoRoot, "models", "all-MiniLM-L6-v2.onnx");
+    private static readonly string VocabPath = Path.Combine(RepoRoot, "models", "vocab.txt");
+    private static bool ArtifactsAvailable => File.Exists(ModelPath) && File.Exists(VocabPath);
+
+    private readonly string _dbPath = Path.Combine(
+        Path.GetTempPath(), $"lve_e2e_{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+    }
+
+    // ── Indexing ────────────────────────────────────────────────────────────
+
+    [SkippableFact]
+    public async Task Index_document_stores_expected_chunk_count()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var embedder = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var chunker = new SlidingWindowChunkingService(chunkSizeWords: 50, overlapWords: 10);
+        using var store = new BLiteVectorStore(_dbPath);
+        var indexer = new DocumentIndexer(chunker, embedder, store);
+
+        // ~30 words → fits in one chunk with chunkSize=50.
+        const string text = "Retrieval-Augmented Generation is a pattern that combines retrieval " +
+                            "and generation to ground LLM answers in external documents. " +
+                            "It uses vector similarity search to find relevant passages.";
+
+        int count = await indexer.IndexDocumentAsync("test-doc", text, "mem://test");
+
+        Assert.Equal(1, count);
+    }
+
+    [SkippableFact]
+    public async Task Index_long_document_produces_multiple_chunks()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var embedder = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var chunker = new SlidingWindowChunkingService(chunkSizeWords: 30, overlapWords: 5);
+        using var store = new BLiteVectorStore(_dbPath);
+        var indexer = new DocumentIndexer(chunker, embedder, store);
+
+        // ~100 words → should produce multiple chunks with chunkSize=30.
+        var words = Enumerable.Range(0, 100).Select(i => $"word{i}");
+        var text = string.Join(' ', words);
+
+        int count = await indexer.IndexDocumentAsync("big-doc", text, "mem://big");
+
+        Assert.True(count >= 3, $"Expected at least 3 chunks from 100 words, got {count}");
+    }
+
+    // ── Retrieval ──────────────────────────────────────────────────────────
+
+    [SkippableFact]
+    public async Task Retrieve_finds_relevant_passage_after_indexing()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var embedder = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var chunker = new SlidingWindowChunkingService(chunkSizeWords: 50, overlapWords: 10);
+        using var store = new BLiteVectorStore(_dbPath);
+        var indexer   = new DocumentIndexer(chunker, embedder, store);
+        var retriever = new RetrievalEngine(embedder, store);
+
+        // Index two topically distinct passages.
+        await indexer.IndexDocumentAsync("ai-doc",
+            "Machine learning is a branch of artificial intelligence that enables " +
+            "computers to learn patterns from data without being explicitly programmed.",
+            "mem://ai");
+
+        await indexer.IndexDocumentAsync("cooking-doc",
+            "To make a perfect risotto, start by toasting the rice in butter, " +
+            "then gradually add warm broth while stirring continuously.",
+            "mem://cooking");
+
+        // Ask an AI-related question.
+        var results = await retriever.RetrieveAsync("What is machine learning?", topK: 2);
+
+        Assert.NotEmpty(results);
+        Assert.Equal("ai-doc", results[0].Chunk.DocumentId);
+        Assert.True(results[0].Score > results[1].Score,
+            "AI passage should score higher than cooking passage for an ML question.");
+    }
+
+    [SkippableFact]
+    public async Task Retrieve_returns_results_sorted_by_descending_score()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var embedder = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var chunker = new SlidingWindowChunkingService(chunkSizeWords: 40, overlapWords: 10);
+        using var store = new BLiteVectorStore(_dbPath);
+        var indexer   = new DocumentIndexer(chunker, embedder, store);
+        var retriever = new RetrievalEngine(embedder, store);
+
+        // Index several passages on different topics.
+        await indexer.IndexDocumentAsync("doc-a",
+            "Vectors in machine learning represent data points in high-dimensional space.",
+            "mem://a");
+        await indexer.IndexDocumentAsync("doc-b",
+            "The French Revolution began in 1789 and transformed French society.",
+            "mem://b");
+        await indexer.IndexDocumentAsync("doc-c",
+            "Cosine similarity measures the angle between two vectors in embedding space.",
+            "mem://c");
+
+        var results = await retriever.RetrieveAsync("How does cosine similarity work?", topK: 3);
+
+        // Scores should be in descending order.
+        for (int i = 0; i < results.Count - 1; i++)
+        {
+            Assert.True(results[i].Score >= results[i + 1].Score,
+                $"Result {i} (score={results[i].Score:F4}) should be >= result {i + 1} (score={results[i + 1].Score:F4})");
+        }
+    }
+
+    [SkippableFact]
+    public async Task Full_pipeline_index_file_then_query()
+    {
+        Skip.IfNot(ArtifactsAvailable);
+
+        using var embedder = new OnnxEmbeddingService(ModelPath, VocabPath);
+        var chunker = new SlidingWindowChunkingService(chunkSizeWords: 50, overlapWords: 10);
+        using var store = new BLiteVectorStore(_dbPath);
+        var indexer   = new DocumentIndexer(chunker, embedder, store);
+        var retriever = new RetrievalEngine(embedder, store);
+
+        // Write a temp file and index it.
+        var tempFile = Path.Combine(Path.GetTempPath(), $"lve_e2e_file_{Guid.NewGuid():N}.txt");
+        const string content = "HNSW is a graph-based algorithm for approximate nearest-neighbour search. " +
+                               "It builds a multi-layer proximity graph where each node represents a vector.";
+        await File.WriteAllTextAsync(tempFile, content);
+
+        try
+        {
+            int chunks = await indexer.IndexFileAsync(tempFile);
+            Assert.True(chunks >= 1);
+
+            var results = await retriever.RetrieveAsync("What is HNSW?", topK: 1);
+
+            Assert.Single(results);
+            Assert.Contains("HNSW", results[0].Chunk.Text);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static string FindRepoRoot(string start)
+    {
+        var dir = new DirectoryInfo(start);
+        while (dir is not null)
+        {
+            if (dir.GetFiles("*.slnx").Length > 0 || Directory.Exists(Path.Combine(dir.FullName, ".git")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return start;
+    }
+}

--- a/tests/LocalVectorEngine.Core.Tests/SlidingWindowChunkingEdgeCaseTests.cs
+++ b/tests/LocalVectorEngine.Core.Tests/SlidingWindowChunkingEdgeCaseTests.cs
@@ -1,0 +1,116 @@
+using LocalVectorEngine.Core.Services;
+using Xunit;
+
+namespace LocalVectorEngine.Core.Tests;
+
+/// <summary>
+/// Additional edge-case coverage for <see cref="SlidingWindowChunkingService"/>.
+/// </summary>
+public class SlidingWindowChunkingEdgeCaseTests
+{
+    private const string DocId  = "edge";
+    private const string Source = "mem://edge";
+
+    [Fact]
+    public void Chunk_single_word_returns_one_chunk()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 2);
+        var chunks = svc.Chunk(DocId, "hello", Source).ToList();
+
+        Assert.Single(chunks);
+        Assert.Equal("hello", chunks[0].Text);
+        Assert.Equal(0, chunks[0].ChunkIndex);
+    }
+
+    [Fact]
+    public void Chunk_text_exactly_chunk_size_returns_one_chunk()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 2);
+        var text = "one two three four five";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Single(chunks);
+        Assert.Equal(text, chunks[0].Text);
+    }
+
+    [Fact]
+    public void Chunk_text_one_word_longer_than_chunk_returns_two_chunks()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 2);
+        // 6 words, step = 3 → windows at 0 and 3
+        var text = "one two three four five six";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal("one two three four five", chunks[0].Text);
+        Assert.Equal("four five six", chunks[1].Text);
+    }
+
+    [Fact]
+    public void Chunk_handles_unicode_text_correctly()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 3, overlapWords: 1);
+        // 6 Unicode words → step = 2 → windows at 0, 2, 4(trailing)
+        var text = "caffè résumé naïve über straße château";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.True(chunks.Count >= 2, $"Expected at least 2 chunks, got {chunks.Count}");
+        Assert.Equal("caffè résumé naïve", chunks[0].Text);
+    }
+
+    [Fact]
+    public void Chunk_handles_CJK_characters_as_words()
+    {
+        // CJK characters separated by spaces are treated as individual words.
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 2, overlapWords: 0);
+        var text = "你好 世界 测试 数据";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal("你好 世界", chunks[0].Text);
+        Assert.Equal("测试 数据", chunks[1].Text);
+    }
+
+    [Fact]
+    public void Chunk_handles_very_long_document()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 100, overlapWords: 25);
+        var words = Enumerable.Range(0, 1000).Select(i => $"word{i}");
+        var text = string.Join(' ', words);
+
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        // 1000 words, step=75 → ceil((1000-100)/75)+1 = 13 chunks
+        Assert.True(chunks.Count >= 12, $"Expected many chunks, got {chunks.Count}");
+
+        // All chunks should have sequential indexes.
+        for (int i = 0; i < chunks.Count; i++)
+            Assert.Equal(i, chunks[i].ChunkIndex);
+
+        // No chunk text should be empty.
+        Assert.All(chunks, c => Assert.False(string.IsNullOrWhiteSpace(c.Text)));
+    }
+
+    [Fact]
+    public void Chunk_preserves_words_with_punctuation()
+    {
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 0);
+        var text = "Hello, world! This is a test.";
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        // Punctuation stays attached to words.
+        Assert.Equal("Hello, world! This is a", chunks[0].Text);
+    }
+
+    [Fact]
+    public void Chunk_with_overlap_one_less_than_chunk_size_produces_many_chunks()
+    {
+        // Extreme overlap: chunkSize=5, overlap=4, step=1.
+        var svc = new SlidingWindowChunkingService(chunkSizeWords: 5, overlapWords: 4);
+        var text = string.Join(' ', Enumerable.Range(0, 10).Select(i => $"w{i}"));
+        var chunks = svc.Chunk(DocId, text, Source).ToList();
+
+        // step=1, so (10-5)/1 + 1 = 6 chunks
+        Assert.Equal(6, chunks.Count);
+    }
+}


### PR DESCRIPTION
Closes #15

- 8 chunking edge cases: single word, exact chunk size, Unicode, CJK, 1000-word doc, punctuation, extreme overlap
- 7 BLiteVectorStore edge cases: topK limiting, fewer results than topK, same docId, multi-doc queries, long text, Unicode metadata, score range
- 5 end-to-end integration tests (SkippableFact, auto-skip without ONNX model): index + retrieve with real services, score ordering, file-based indexing
- Total: 84 tests (up from 64)